### PR TITLE
Split system role into independent evaluator

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,8 @@
     "https://json.schemastore.org/github-workflow.json": [
       ".github/workflows/**/*.yaml"
     ]
-  }
+  },
+  "java.test.config": {
+    "envFile": "${workspaceFolder}/.env"
+  },
 }

--- a/security/src/main/java/com/example/security/CustomPermissionEvaluator.java
+++ b/security/src/main/java/com/example/security/CustomPermissionEvaluator.java
@@ -14,8 +14,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.PermissionEvaluator;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
@@ -25,7 +23,7 @@ import org.springframework.web.client.RestTemplate;
 @Component
 public class CustomPermissionEvaluator implements PermissionEvaluator {
   private final Logger logger = LoggerFactory.getLogger(CustomPermissionEvaluator.class);
-  public static GrantedAuthority SYSTEM_ROLE = new SimpleGrantedAuthority("ROLE_SYSTEM");
+  private final SystemRolePermissionEvaluator systemRoleEvaluator = new SystemRolePermissionEvaluator();
 
   private final OAuth2AuthorizedClientService authorizedClientService;
   private String authzurl;
@@ -51,7 +49,8 @@ public class CustomPermissionEvaluator implements PermissionEvaluator {
       return false;
     }
 
-    if (authentication.getAuthorities().contains(SYSTEM_ROLE)) {
+    // TODO: remove after we test a CompositePermissionEvaluator
+    if (systemRoleEvaluator.hasPermission(authentication, targetDomainObject, permission)) {
       return true;
     }
 
@@ -66,7 +65,8 @@ public class CustomPermissionEvaluator implements PermissionEvaluator {
       return false;
     }
 
-    if (authentication.getAuthorities().contains(SYSTEM_ROLE)) {
+    // TODO: remove after we test a CompositePermissionEvaluator
+    if (systemRoleEvaluator.hasPermission(authentication, targetId, targetType, permission)) {
       return true;
     }
 

--- a/security/src/main/java/com/example/security/SystemRolePermissionEvaluator.java
+++ b/security/src/main/java/com/example/security/SystemRolePermissionEvaluator.java
@@ -1,0 +1,28 @@
+package com.example.security;
+
+import java.io.Serializable;
+
+import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+public class SystemRolePermissionEvaluator implements PermissionEvaluator {
+  public static GrantedAuthority SYSTEM_ROLE = new SimpleGrantedAuthority("ROLE_SYSTEM");
+
+  @Override
+  public boolean hasPermission(Authentication authentication, Object targetDomainObject, Object permission) {
+    return hasSystemRole(authentication);
+  }
+
+  @Override
+  public boolean hasPermission(Authentication authentication, Serializable targetId, String targetType,
+      Object permission) {
+    return hasSystemRole(authentication);
+  }
+
+  public boolean hasSystemRole(Authentication authentication) {
+    return authentication != null && authentication.getAuthorities().contains(SYSTEM_ROLE);
+  }
+
+}

--- a/security/src/main/java/com/example/security/SystemSecurityContext.java
+++ b/security/src/main/java/com/example/security/SystemSecurityContext.java
@@ -1,0 +1,25 @@
+package com.example.security;
+
+import java.util.Collections;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SystemSecurityContext implements AutoCloseable {
+
+  public SystemSecurityContext() {
+    SecurityContextHolder.getContext().setAuthentication(
+        new UsernamePasswordAuthenticationToken("system", null,
+            Collections.singletonList(SystemRolePermissionEvaluator.SYSTEM_ROLE)));
+  }
+
+  @Override
+  public void close() throws Exception {
+    SecurityContextHolder.clearContext();
+  }
+
+  public Authentication getAuthentication() {
+    return SecurityContextHolder.getContext().getAuthentication();
+  }
+}

--- a/security/src/main/java/com/example/security/SystemSecurityContext.java
+++ b/security/src/main/java/com/example/security/SystemSecurityContext.java
@@ -15,7 +15,7 @@ public class SystemSecurityContext implements AutoCloseable {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     SecurityContextHolder.clearContext();
   }
 

--- a/security/src/test/java/com/example/security/SystemRolePermissionEvaluatorTests.java
+++ b/security/src/test/java/com/example/security/SystemRolePermissionEvaluatorTests.java
@@ -1,0 +1,24 @@
+package com.example.security;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+public class SystemRolePermissionEvaluatorTests {
+  @Test
+  void deniesByDefault() {
+    SystemRolePermissionEvaluator evaluator = new SystemRolePermissionEvaluator();
+
+    assertFalse(evaluator.hasPermission(null, new Object(), "read"));
+    assertFalse(evaluator.hasPermission(null, 1, "Object", "read"));
+  }
+
+  @Test
+  void allowsSystemRole() throws Exception {
+    try (SystemSecurityContext context = new SystemSecurityContext()) {
+      SystemRolePermissionEvaluator evaluator = new SystemRolePermissionEvaluator();
+      assertTrue(evaluator.hasPermission(context.getAuthentication(), new Object(), "read"));
+      assertTrue(evaluator.hasPermission(context.getAuthentication(), 1, "Object", "read"));
+    }
+  }
+}

--- a/security/src/test/java/com/example/security/SystemRolePermissionEvaluatorTests.java
+++ b/security/src/test/java/com/example/security/SystemRolePermissionEvaluatorTests.java
@@ -14,7 +14,7 @@ public class SystemRolePermissionEvaluatorTests {
   }
 
   @Test
-  void allowsSystemRole() throws Exception {
+  void allowsSystemRole() {
     try (SystemSecurityContext context = new SystemSecurityContext()) {
       SystemRolePermissionEvaluator evaluator = new SystemRolePermissionEvaluator();
       assertTrue(evaluator.hasPermission(context.getAuthentication(), new Object(), "read"));

--- a/security/src/test/java/com/example/security/SystemSecurityContextTests.java
+++ b/security/src/test/java/com/example/security/SystemSecurityContextTests.java
@@ -13,7 +13,7 @@ public class SystemSecurityContextTests {
   }
 
   @Test
-  void contextSetsSystemRoleAuthentication() throws Exception {
+  void contextSetsSystemRoleAuthentication() {
     try (SystemSecurityContext context = new SystemSecurityContext()) {
       var authentication = SecurityContextHolder.getContext().getAuthentication();
       assertNotNull(authentication);
@@ -24,14 +24,14 @@ public class SystemSecurityContextTests {
   }
 
   @Test
-  void getAuthenticationReturnsSecurityContextHolderAuthentication() throws Exception {
+  void getAuthenticationReturnsSecurityContextHolderAuthentication() {
     try (SystemSecurityContext context = new SystemSecurityContext()) {
       assertEquals(context.getAuthentication(), SecurityContextHolder.getContext().getAuthentication());
     }
   }
 
   @Test
-  void resetsAuthenticationAfterClose() throws Exception {
+  void resetsAuthenticationAfterClose() {
     try (SystemSecurityContext context = new SystemSecurityContext()) {
       assertNotNull(SecurityContextHolder.getContext().getAuthentication());
     }

--- a/security/src/test/java/com/example/security/SystemSecurityContextTests.java
+++ b/security/src/test/java/com/example/security/SystemSecurityContextTests.java
@@ -1,0 +1,40 @@
+package com.example.security;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SystemSecurityContextTests {
+  @Test
+  void defaultHasNoAuthentication() {
+    var authentication = SecurityContextHolder.getContext().getAuthentication();
+    assertNull(authentication);
+  }
+
+  @Test
+  void contextSetsSystemRoleAuthentication() throws Exception {
+    try (SystemSecurityContext context = new SystemSecurityContext()) {
+      var authentication = SecurityContextHolder.getContext().getAuthentication();
+      assertNotNull(authentication);
+      assertEquals("system", authentication.getName());
+      assertEquals(1, authentication.getAuthorities().size());
+      assertEquals("ROLE_SYSTEM", authentication.getAuthorities().iterator().next().getAuthority());
+    }
+  }
+
+  @Test
+  void getAuthenticationReturnsSecurityContextHolderAuthentication() throws Exception {
+    try (SystemSecurityContext context = new SystemSecurityContext()) {
+      assertEquals(context.getAuthentication(), SecurityContextHolder.getContext().getAuthentication());
+    }
+  }
+
+  @Test
+  void resetsAuthenticationAfterClose() throws Exception {
+    try (SystemSecurityContext context = new SystemSecurityContext()) {
+      assertNotNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+    assertNull(SecurityContextHolder.getContext().getAuthentication());
+  }
+}

--- a/webapi/src/main/java/com/example/webapi/DebugController.java
+++ b/webapi/src/main/java/com/example/webapi/DebugController.java
@@ -22,7 +22,7 @@ public class DebugController {
 
   @GetMapping(value = "/me", produces = "application/json")
   @ResponseBody
-  public String me() throws Exception {
+  public String me() {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     String accessToken = authorizedClientService.loadAuthorizedClient("pingidentity", authentication.getName())
         .getAccessToken()

--- a/webapi/src/main/java/com/example/webapi/WebapiApplication.java
+++ b/webapi/src/main/java/com/example/webapi/WebapiApplication.java
@@ -1,15 +1,11 @@
 package com.example.webapi;
 
-import java.util.Collections;
-
-import com.example.security.CustomPermissionEvaluator;
+import com.example.security.SystemSecurityContext;
 
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -25,18 +21,12 @@ public class WebapiApplication {
 	@Bean
 	CommandLineRunner initThings(ThingRepository repository) {
 		return args -> {
-			try {
-				SecurityContextHolder.getContext().setAuthentication(
-						new UsernamePasswordAuthenticationToken("system", null,
-								Collections.singletonList(CustomPermissionEvaluator.SYSTEM_ROLE)));
-
+			try (var _context = new SystemSecurityContext()) {
 				for (int i = 0; i < 10; i++) {
 					Thing thing = new Thing();
 					thing.setName("Thing " + i);
 					repository.save(thing);
 				}
-			} finally {
-				SecurityContextHolder.clearContext();
 			}
 		};
 	}

--- a/webapi/src/test/java/com/example/webapi/ThingRepositoryTests.java
+++ b/webapi/src/test/java/com/example/webapi/ThingRepositoryTests.java
@@ -1,0 +1,29 @@
+package com.example.webapi;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.example.security.SystemSecurityContext;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+
+@SpringBootTest
+public class ThingRepositoryTests {
+
+  @Autowired
+  private ThingRepository repository;
+
+  @Test
+  void getAll_DeniesUnauthenticatedUsers() {
+    assertThrows(AuthenticationCredentialsNotFoundException.class, () -> repository.getById(Long.valueOf(1)));
+  }
+
+  @Test
+  void getAll_AllowsSystemUsers() {
+    try (var context = new SystemSecurityContext()) {
+      assertDoesNotThrow(() -> repository.findById(Long.valueOf(1)));
+    }
+  }
+}


### PR DESCRIPTION
Adds `SystemRolePermissionEvaluator` to define & check for a "system" role - so internal trusted code (ex: startup scripts) can call protected methods

Add `SystemSecurityContext` utility - an `AutoCloseable` that sets the current security context to hold the aforementioned system role, then clearing it at the end of the scope