### PR TITLE
Composite permission evaluator

### DIFF
--- a/security/src/main/java/com/example/security/CompositePermissionEvaluator.java
+++ b/security/src/main/java/com/example/security/CompositePermissionEvaluator.java
@@ -1,0 +1,40 @@
+package com.example.security;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.core.Authentication;
+
+public class CompositePermissionEvaluator implements PermissionEvaluator  {
+
+    private List<PermissionEvaluator> evaluators;
+
+    public CompositePermissionEvaluator(List<PermissionEvaluator> evaluators)
+    {
+      super();
+      this.evaluators = evaluators;
+    }
+  
+    @Override
+    public boolean hasPermission(Authentication authentication, Object targetDomainObject, Object permission)
+    {
+      return evaluators.stream()
+          .map(ev -> ev.hasPermission(authentication, targetDomainObject, permission))
+          .reduce(Boolean::logicalOr)
+          .orElse(false);
+    }
+  
+    @Override
+    public boolean hasPermission(
+        Authentication authentication,
+        Serializable targetId,
+        String targetType,
+        Object permission)
+    {
+        return evaluators.stream()
+            .map(ev -> ev.hasPermission(authentication, targetId, targetType, permission))
+            .reduce(Boolean::logicalOr)
+            .orElse(false);
+    }
+}

--- a/webapi/src/main/java/com/example/webapi/MethodSecurityConfig.java
+++ b/webapi/src/main/java/com/example/webapi/MethodSecurityConfig.java
@@ -1,10 +1,13 @@
 package com.example.webapi;
 
-import com.example.security.CustomPermissionEvaluator;
+import java.util.List;
+
+import com.example.security.CompositePermissionEvaluator;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.PermissionEvaluator;
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -13,10 +16,12 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 @ComponentScan("com.example.security")
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 public class MethodSecurityConfig {
+
   @Bean
-  static MethodSecurityExpressionHandler methodSecurityExpressionHandler(CustomPermissionEvaluator evaluator) {
+  static MethodSecurityExpressionHandler methodSecurityExpressionHandler(List<PermissionEvaluator> evaluators) {
     DefaultMethodSecurityExpressionHandler handler = new DefaultMethodSecurityExpressionHandler();
-    handler.setPermissionEvaluator(evaluator);
+    CompositePermissionEvaluator eval = new CompositePermissionEvaluator(evaluators);
+    handler.setPermissionEvaluator(eval);
     return handler;
   }
 }


### PR DESCRIPTION
- adds a composite permission evaluator so that multiple evaluators can be used

A new PermissionEvaluator can be pulled into the the methodSecurityExpressionHandler method by adding the @Component annotation above the class